### PR TITLE
Bump to version 2.0.0

### DIFF
--- a/lib/ddtrace/version.rb
+++ b/lib/ddtrace/version.rb
@@ -2,9 +2,9 @@
 
 module DDTrace
   module VERSION
-    MAJOR = 1
-    MINOR = 21
-    PATCH = 1
+    MAJOR = 2
+    MINOR = 0
+    PATCH = 0
     PRE = nil
     BUILD = nil
     # PRE and BUILD above are modified for dev gems during gem build GHA workflow


### PR DESCRIPTION
### Added

* Add Agent configuration option: `timeout_seconds`, `uds_path`, and `use_ssl` (#3350)
* Tracing: Add lightweight log correlation generation (#3486)
* Tracing: Add span links (#3546)
* Tracing: Add `span_remote` field to `TraceDigest` (#3516)
* Tracing: Add `_dd.parent_id` to `tracestate` (#3488)
* Tracing: Allow `RateSampler` with zero sampling rate (#3295)
* Grape: Add `on_error` settings (#3370)

### Changed

* Rename gem from `ddtrace` to `datadog` (#3490)
* Require Ruby `>= 2.5` (#3291)
* Frozen string literals (#3392)
* Startup logs emit when reconfigures (#3441)
* Enhance validation for configuration (#3332, #3326)
* Tracing: Propagation style configuration becomes case-insensitive (#3299)
* Tracing: Return string for `#trace_id` and `#span_id` from `Correlation::Identifier` (#3322)
* `Elasticsearch`: Replace instance configuration from `client` to `transport` instance (#3399)
* `Grape`: Change `error_statuses` settings to `error_status_codes` (#3370)
* `GraphQL`: Instrument with `GraphQL::Tracing::DataDogTrace` and more (#3409, #3417, #3388)
* `Rack`: Change http proxy span pattern (#3369)
* `Sidekiq`: Remove `tag_args` option and worker specific configuration (#3396, #3402)
* Integrations: Rename `error_handler` settings to `on_error` (#3341)
*
### Fixed

* Tracing: Fix `error_status_codes` options (#3344)

### Removed

* Profiling: Remove `bin/ddtracerb` (#3506)
* Ci-app: Remove `datadog-ci` gem dependency (#3288)
* Tracing: Remove `SpanOperation` aliases (#3330)
* Tracing: Remove `b3` style from default propagation (#3293)
* Tracing: Minimize sampling API (#3423)
* Tracing: Remove `client_ip` disabled env (#3404)
* Tracing: Remove `use` alias for `instrument` (#3403)
* Tracing: `OpenTracing`, `qless` removed (#3398, #3443)
* `Net/Http`: Remove `Datadog::Tracing::Contrib::HTTP::Instrumentation.after_request` (#3367)
* `Rails`: Drop support for Rails 3 (#3324)
* `Rails`: Remove `exception_controller` option (#3243)
* Remove constants, methods and more (#3401, #3336, #3454, #3338, #3335, #3298, #3297, #3309, #3294, #3325, #3300)



